### PR TITLE
Remove lock on 'line' cookbook and add a Policyfile option for future use.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,21 +12,15 @@ AllCops:
     - 'test/**/*'
     - 'bin/**'
     - 'vendor/**/*'
-AlignParameters:
+    - 'airlift/**/*'
+    - 'kitchen-zone/**/*'
+Layout/LineLength:
   Enabled: false
-ClassLength:
+Layout/ParameterAlignment:
   Enabled: false
-CyclomaticComplexity:
+Layout/SpaceBeforeFirstArg:
   Enabled: false
-Documentation:
-  Enabled: false
-Encoding:
-  Enabled: false
-Layout/IndentationWidth:
-  Enabled: false
-LineLength:
-  Enabled: false
-MethodLength:
+Lint/SendWithMixinArgument:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
@@ -36,17 +30,25 @@ Naming/FileName:
   Enabled: false
 Naming/HeredocDelimiterNaming:
   Enabled: false
-PerceivedComplexity:
+Metrics/ClassLength:
   Enabled: false
-SpaceBeforeFirstArg:
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
   Enabled: false
 Style/ClassAndModuleChildren:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/Encoding:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
   Enabled: false
-Style/PercentLiteralDelimiters:
-  Enabled: false
 Style/ModuleFunction:
+  Enabled: false
+Style/PercentLiteralDelimiters:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v3.0.0
+- Update to use the newer `line` cookbook.
+
 ## v2.0.0
 - Overhaul the cookbook to use standard Chef custom resources.
 

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,6 @@
+name 'rc'
+default_source :community
+
+cookbook 'rc', path: '.'
+
+run_list %w{rc::default} # Remove guts from run due to issue with service restarting on windows

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'chef@bloomberg.net'
 license 'Apache-2.0'
 description 'Library cookbook which provides a resource for writing runtime configuration files.'
 long_description 'Library cookbook which provides a resource for writing runtime configuration files.'
-version '2.0.0'
+version '3.0.0'
 source_url 'https://github.com/bloomberg-cookbooks/rc' if defined?(:source_url)
 issues_url 'https://github.com/bloomberg-cookbooks/rc/issues' if defined?(:source_url)
 chef_version '>= 12.5.0'
@@ -17,4 +17,4 @@ supports 'freebsd'
 supports 'aix'
 supports 'solaris2'
 
-depends 'line', '~> 0.6'
+depends 'line'


### PR DESCRIPTION
The `line` cookbook being pinned to 0.6.x previously can cause issues. In our case, a developer tested a cookbook depending on `line` in isolation, which pulled down a current version of the `line` cookbook (2.7.0 is current right now); that has supported regexes in `delete_lines` [since 1.1.0 in March 2018](https://github.com/sous-chefs/line/blob/master/CHANGELOG.md#v110-2018-03-26). However, the pin here meant that when it was incorporated into a larger policy that also included the `rc` cookbook, the code broke all of a sudden.

After doing some testing, there doesn't appear to be a reason for this pin to be present. No code changes were necessary to cooperate with the newer `line` cookbook, either in this cookbook or, in my testing, a cookbook invoking the `rc` cookbook. As a result. I'm not just going to bump the pin up, I'm going to let it float freely so that this kind of situation won't happen in the future.